### PR TITLE
route logFile & Unity exit code

### DIFF
--- a/UnityProxy/Program.cs
+++ b/UnityProxy/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 
 namespace UnityProxy
@@ -61,15 +62,24 @@ namespace UnityProxy
 				SaveArtifacts(artifactsPath, watcher.FullLog);
 			}
 
-			if (watcher.FullLog.Contains(SuccessMagicString))
+			bool isBuilding = args.Contains("-executeMethod");
+			if (isBuilding)
 			{
-				Console.WriteLine("Success.");
-				Environment.Exit(0);
+				if (watcher.FullLog.Contains(SuccessMagicString))
+				{
+					Console.WriteLine("Success.");
+					Environment.Exit(0);
+				}
+				else
+				{
+					Console.WriteLine("Failure.");
+					Environment.Exit(1);
+				}
 			}
 			else
 			{
-				Console.WriteLine("Failure.");
-				Environment.Exit(1);
+				// just reimporting, not building
+				Environment.Exit(unity.ExitCode);
 			}
 		}
 

--- a/UnityProxy/Program.cs
+++ b/UnityProxy/Program.cs
@@ -26,6 +26,10 @@ namespace UnityProxy
 				{
 					logPath = args[i + 1];
 					hasLogFileArgument = true;
+					if (File.Exists(logPath))
+					{
+						File.Delete(logPath);
+					}
 					break;
 				}
 			}

--- a/UnityProxy/Program.cs
+++ b/UnityProxy/Program.cs
@@ -16,7 +16,18 @@ namespace UnityProxy
 		{
 			string unityPath, artifactsPath;
 			int startingArgumentIndex = ParseArguments(args, out unityPath, out artifactsPath);
+
 			string logPath = Path.GetTempFileName();
+			bool hasLogFileArgument = false;
+			for (int i = startingArgumentIndex; i < args.Length; i++)
+			{
+				if (args[i] == "-logFile")
+				{
+					logPath = args[i + 1];
+					hasLogFileArgument = true;
+					break;
+				}
+			}
 
 			Watcher watcher = new Watcher(logPath);
 			Thread watcherThread = new Thread(watcher.Run);
@@ -25,7 +36,10 @@ namespace UnityProxy
 			Process unity = new Process();
 			unity.StartInfo = new ProcessStartInfo(unityPath);
 
-			unity.StartInfo.Arguments = "-logFile \"" + logPath + "\"";
+			if (!hasLogFileArgument)
+			{
+				unity.StartInfo.Arguments = "-logFile \"" + logPath + "\"";
+			}
 
 			for (int i = startingArgumentIndex; i < args.Length; i++)
 			{


### PR DESCRIPTION
Great tool, thanks for sharing!

No idea if this is of interest to you, but I've configured it to fit our own build process, where:
- we specify our own log file, to be copied to the output directory
- we have several build steps, one that just launches Unity for switching the platform (just import and exit), and one for doing the actual build.

Regarding the -artifactsPath argument, is there a reason why you're writing a file containing the watcher.FullLog string, instead of simply copying the temp logFile?
